### PR TITLE
Add URL variables

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -144,6 +144,27 @@
                                                     </tbody>
                                                 </table>
                                                 @{{ end }}@
+                                                @{{ if $item.Request.URL.Variables }}@
+                                                <h5 class="label label-info">URL Variables</h5>
+                                                <table class="table table-hover">
+                                                    <thead>
+                                                    <tr>
+                                                        <th>Key</th>
+                                                        <th>Value</th>
+                                                        <th>Description</th>
+                                                    </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                    @{{ range $iq, $q := $item.Request.URL.Variables }}@
+                                                    <tr>
+                                                        <td>@{{ $q.Key }}@</td>
+                                                        <td>@{{ $q.Value }}@</td>
+                                                        <td>@{{ $q.Description | markdown | html }}@</td>
+                                                    </tr>
+                                                    @{{ end }}@
+                                                    </tbody>
+                                                </table>
+                                                @{{ end }}@
 
                                                 @{{ if $item.Request.Body.Mode}}@
                                                     @{{ if eq $item.Request.Body.Mode "raw"}}@

--- a/assets/index.md
+++ b/assets/index.md
@@ -67,6 +67,19 @@ URL: @{{ $item.Request.URL.Raw | trimQueryParams}}@
 @{{ end }}@
 <!--- End query param items -->
 
+<!--- URL variables items -->
+@{{ if $item.Request.URL.Variables }}@
+***URL variables:***
+
+<!--- URL variables items -->
+| Key | Value | Description |
+| --- | ------|-------------|
+@{{ range $iq, $q := $item.Request.URL.Variables -}}@
+| @{{ $q.Key }}@ | @{{ $q.Value }}@ | @{{ $q.Description }}@ |
+@{{ end }}@
+@{{ end }}@
+<!--- End URL variables items -->
+
 <!--- Body mode -->
 @{{ if $item.Request.Body.Mode}}@
 <!--- Raw body data -->

--- a/collection.go
+++ b/collection.go
@@ -7,7 +7,6 @@ import (
 )
 
 type (
-
 	// Root describes the full data read from file
 	Root struct {
 		Info        Info         `json:"info"`
@@ -40,11 +39,18 @@ type (
 
 	// URL describes URL of the request
 	URL struct {
-		Raw         string   `json:"raw"`
-		Host        []string `json:"host"`
-		Path        []string `json:"path"`
-		Description string   `json:"description"`
-		Query       []Field  `json:"query"`
+		Raw         string     `json:"raw"`
+		Host        []string   `json:"host"`
+		Path        []string   `json:"path"`
+		Description string     `json:"description"`
+		Query       []Field    `json:"query"`
+		Variables   []Variable `json:"variable"`
+	}
+
+	Variable struct {
+		Key         string `json:"key"`
+		Value       string `json:"value"`
+		Description string `json:"description"`
 	}
 
 	// Body describes a request body


### PR DESCRIPTION
Add URL variables (eg. `:variablename` in the URL) in both HTML and Markdown templates.