### PR TITLE
Add `-s` switch to enable collection sorting

### DIFF
--- a/build.go
+++ b/build.go
@@ -8,6 +8,7 @@ var (
 	in          string
 	out         string
 	isMarkdown  bool
+	sortEnabled bool
 	buildOutput = &cobra.Command{
 		Use:   "build",
 		Short: "Build html/markdown documentation from postman collection",
@@ -17,6 +18,7 @@ var (
 )
 
 func init() {
+	buildOutput.PersistentFlags().BoolVarP(&sortEnabled, "sort", "s", false, "sort the collection list")
 	buildOutput.PersistentFlags().StringVarP(&in, "in", "i", "", "postman collection file relative path")
 	buildOutput.PersistentFlags().StringVarP(&out, "out", "o", "", "output file relative path")
 	buildOutput.PersistentFlags().BoolVarP(&isMarkdown, "md", "m", false, "this flag will command to generate markdown")

--- a/collection.go
+++ b/collection.go
@@ -113,7 +113,9 @@ func (r *Root) Open(rdr io.Reader) error {
 		return err
 	}
 	r.build()
-	r.sortCollections()
+	if sortEnabled {
+		r.sortCollections()
+	}
 
 	r.removeEmptyCollections()
 

--- a/main.go
+++ b/main.go
@@ -187,5 +187,8 @@ func readJSONtoMarkdownHTML(str string) *bytes.Buffer {
 	return buf
 }
 func main() {
-	cmd.Execute()
+	err := cmd.Execute()
+	if err != nil {
+		panic(err)
+	}
 }

--- a/server.go
+++ b/server.go
@@ -26,6 +26,7 @@ func init() {
 	serveLive.PersistentFlags().IntVarP(&port, "port", "p", 9000, "port number to listen")
 	serveLive.PersistentFlags().StringVarP(&file, "file", "f", "", "postman collection file's relative path")
 	serveLive.PersistentFlags().BoolVarP(&isMarkdown, "md", "m", false, "display markdown format in preview")
+	serveLive.PersistentFlags().BoolVarP(&sortEnabled, "sort", "s", false, "sort the collection list")
 }
 
 func server(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
The default/expected behavior is to use current order from the JSON array, which comes from Postman itself (from user-chosen order in UI). This pull request is disabling the sorting is the switch `-s`/`-sort` is not specified (explicit action to override current sort order).