### PR TITLE
Removing the lexical sort.

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -108,8 +108,8 @@ func (d *Documentation) Open(rdr io.Reader) error {
 	d.removeItemRequestDisabledField()
 	d.removeItemResponseRequestDisabledField()
 
-	// sort the collections in lexical order
-	d.sortCollections()
+	// // sort the collections in lexical order
+	// d.sortCollections()
 
 	return nil
 }


### PR DESCRIPTION
Based on this issue https://github.com/thedevsaddam/docgen/issues/54

Not sure how to add a flag for this, haven't actually used golang myself.

Either way, there should be no need to alter the order of the files that were made by the people maintaining their collection.