### PR TITLE
Don't rely on _postman_isSubFolder 

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -144,7 +144,7 @@ func (d *Documentation) build() {
 
 // buildSubChildItems builds all the sub folder collections
 func (d *Documentation) buildSubChildItems(itm Item, c *Collection, pn string) bool {
-	if itm.IsSubFolder {
+	if len(itm.Items) > 0 {
 		collection := Collection{}
 		collection.Name = pn + "/" + itm.Name
 		collection.IsSubFolder = true


### PR DESCRIPTION
When exporting a collection from some Postman versions the `_postman_isSubFolder` field is not included in the generated Json. I suggest to consider a subfolder any Item which includes at least one Item itself.

The missing `_postman_isSubFolder` has been observed on Postman versions v9.0.7 and v9.1.1 on Arch, as well as v9.1.2 on Windows. The problem is there for both v2 and v2.1 Collections.

