### PR TITLE
Fix links to markdown anchors; Resolve issue #62

### DIFF
--- a/cmd/funcmap.go
+++ b/cmd/funcmap.go
@@ -84,8 +84,8 @@ func githubLink(v string) string {
 	v = strings.ToLower(v)
 
 	v = strings.Replace(v, " ", "-", -1)
-	v = strings.Replace(v, ".", "", -1)
-	v = strings.Replace(v, "/", "", -1)
+	nonWordChars := regexp.MustCompile(`[^-\w\d]`)
+	v = nonWordChars.ReplaceAllString(v, "")
 	return v
 }
 


### PR DESCRIPTION
Removes any non word or digit (excluding hyphens "-") from links to anchors in markdown document. 